### PR TITLE
fix: 当搜索框输入为空时，阻止搜索

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -79,7 +79,11 @@ import LazyLoad from "vanilla-lazyload";
 
       $search.find('form').on('submit', e => {
         e.preventDefault();
-        window.open($search.find('.search-tab a.active').data('url') + $search.find('input').val());
+        const keyword = $search.find('input').val().trim();
+        if (!keyword) {
+          return;
+        }
+        window.open($search.find('.search-tab a.active').data('url') + keyword);
       });
     }
 


### PR DESCRIPTION
将不再能够通过按 Enter 键来触发空的搜索
